### PR TITLE
Adds slash commands, allows to run commands while in chat mode

### DIFF
--- a/app/Commands/DroidCommand.php
+++ b/app/Commands/DroidCommand.php
@@ -3,6 +3,7 @@
 namespace App\Commands;
 
 use App\Services\ChatAssistant;
+use App\Tools\ExecuteCommand;
 use App\Utils\OnBoardingSteps;
 use Exception;
 use Illuminate\Console\Command;
@@ -13,7 +14,14 @@ class DroidCommand extends Command
 {
     public $signature = 'droid';
 
-    public $description = 'Allows you to create/update a feature';
+    public $description = 'Allows you to create/update a feature and run commands';
+
+    public function __construct(
+        private readonly ChatAssistant  $chatAssistant,
+        private readonly ExecuteCommand $executeCommand
+    ) {
+        parent::__construct();
+    }
 
     /**
      * @throws Exception
@@ -25,8 +33,7 @@ class DroidCommand extends Command
             return self::FAILURE;
         }
 
-        $chatAssistant = new ChatAssistant;
-        $thread = $chatAssistant->createThread();
+        $thread = $this->chatAssistant->createThread();
 
         while (true) {
             $message = ask('<span class="mt-1 mx-1">🍻:</span>');
@@ -35,7 +42,11 @@ class DroidCommand extends Command
                 break;
             }
 
-            $chatAssistant->getAnswer($thread, $message);
+            if (str_starts_with($message, '/')) {
+                $this->executeCommand->handle(substr($message, 1));
+            } else {
+                $this->chatAssistant->getAnswer($thread, $message);
+            }
         }
 
         return self::SUCCESS;

--- a/tests/Feature/InspireCommandTest.php
+++ b/tests/Feature/InspireCommandTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('inspires artisans', function () {
-    $this->artisan('inspire')->assertExitCode(0);
-});


### PR DESCRIPTION
This pull request introduces slash commands to the chat mode, allowing users to execute specific commands while interacting with the AI assistant. This feature enhances the functionality and flexibility of the chat interface, enabling users to perform various actions seamlessly during conversations.

## Example Usage
```sh
# command
/git status

# output
✅ ExecuteCommand: git status:

On branch pr-14
nothing to commit, working tree clean
```
